### PR TITLE
Make the destructor of converters public

### DIFF
--- a/src/converter_sosi2mysql.h
+++ b/src/converter_sosi2mysql.h
@@ -313,13 +313,13 @@ namespace sosicon {
                         std::string dbSchema,
                         std::string dbTable );
 
-        //! Destructor
-        virtual ~ConverterSosi2mysql() { }
-
     public:
 
         //! Constructor
         ConverterSosi2mysql() : mCmd( 0 ) { }
+
+        //! Destructor
+        virtual ~ConverterSosi2mysql() { }
 
         //! Initialize converter
         /*!

--- a/src/converter_sosi2psql.h
+++ b/src/converter_sosi2psql.h
@@ -303,14 +303,14 @@ namespace sosicon {
                         std::string dbSchema,
                         std::string dbTable );
 
-        //! Destructor
-        virtual ~ConverterSosi2psql() { }
-
     public:
 
         //! Constructor
         ConverterSosi2psql() : mCmd( 0 ) { }
         
+        //! Destructor
+        virtual ~ConverterSosi2psql() { }
+
         //! Initialize converter
         /*!
             Implementation details in sosicon::IConverter::init()

--- a/src/converter_sosi2tsv.h
+++ b/src/converter_sosi2tsv.h
@@ -41,13 +41,14 @@ namespace sosicon {
         //! Command line wrapper
         CommandLine* mCmd;
 
-        //! Destructor
-        virtual ~ConverterSosi2tsv() { };
-
     public:
         //! Constructor
         ConverterSosi2tsv() : mCmd( 0 ) { };
-        
+
+        //! Destructor
+        virtual ~ConverterSosi2tsv() { };
+
+
         //! Initialize converter
         /*!
             Implementation details in sosicon::IConverter::init()


### PR DESCRIPTION
Hi,

I am wrapping some of these classes with Pybind11 to make a python library that can read sosi files. I had a problem with the private destructors of these classes when i tried to instanciate them on the stack. What do you think about making the destructors public? This is what this pull request does. 

Thank you for considering the request. 